### PR TITLE
feat(training-history): Implement Training History CRUD functionality

### DIFF
--- a/app/Http/Controllers/User/TrainingHistoryController.php
+++ b/app/Http/Controllers/User/TrainingHistoryController.php
@@ -3,63 +3,108 @@
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
+use App\Models\TrainingRecord;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class TrainingHistoryController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
+    public function index(Request $request)
     {
-        return view('user.training-history.index');
+        $records = TrainingRecord::query()
+            ->with(['menu', 'template', 'details.exercise'])
+            ->where('user_id', Auth::id());
+
+        // クイックフィルター処理
+        if ($request->filled('filter')) {
+            switch ($request->filter) {
+                case 'this_week':
+                    $records->whereBetween('training_date', [
+                        now()->startOfWeek(),
+                        now()->endOfWeek(),
+                    ]);
+                    break;
+                case 'this_month':
+                    $records->whereBetween('training_date', [
+                        now()->startOfMonth(),
+                        now()->endOfMonth(),
+                    ]);
+                    break;
+                case 'last_30_days':
+                    $records->whereBetween('training_date', [
+                        now()->subDays(30),
+                        now(),
+                    ]);
+                    break;
+            }
+        }
+
+        // 既存のフィルター処理
+        $records->when($request->filled('date'), fn ($q) => $q->whereDate('training_date', $request->date))
+            ->when($request->filled('date_from'), fn ($q) => $q->whereDate('training_date', '>=', $request->date_from))
+            ->when($request->filled('date_to'), fn ($q) => $q->whereDate('training_date', '<=', $request->date_to))
+            ->when($request->filled('template'), function ($q) use ($request) {
+                $q->whereHas('template', fn ($t) => $t->where('slug', $request->template));
+            })
+            ->when($request->filled('keyword'), function ($q) use ($request) {
+                $q->where(function ($query) use ($request) {
+                    $query->whereHas('menu', fn ($m) => $m->where('name', 'like', '%'.$request->keyword.'%'))
+                        ->orWhere('note', 'like', '%'.$request->keyword.'%');
+                });
+            });
+
+        $records = $records->latest('training_date')
+            ->paginate(10)
+            ->withQueryString();
+
+        $details = $records->getCollection()->pluck('details')->flatten();
+        $totalSets = $details->count();
+        $totalReps = $details->sum('reps');
+        $totalVolume = $details->sum('volume');
+
+        return view('user.training-history.index', compact(
+            'records',
+            'totalSets',
+            'totalReps',
+            'totalVolume'
+        ));
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show()
-    {
-        return view('user.training-history.show');
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(string $id)
     {
-        //
+        $record = TrainingRecord::where('user_id', Auth::id())->findOrFail($id);
+        $record->delete();
+
+        return redirect()->route('training-history.index')->with('success', 'トレーニング記録を削除しました');
+    }
+
+    public function show(string $id)
+    {
+        $record = TrainingRecord::with(['menu', 'template', 'details.exercise'])
+            ->where('user_id', Auth::id())
+            ->findOrFail($id);
+
+        return view('user.training-history.show', compact('record'));
+    }
+
+    public function edit(string $id)
+    {
+        $record = TrainingRecord::where('user_id', Auth::id())->findOrFail($id);
+
+        return view('user.training-history.edit', compact('record'));
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $record = TrainingRecord::where('user_id', Auth::id())->findOrFail($id);
+
+        $validated = $request->validate([
+            'training_date' => 'required|date',
+            'note' => 'nullable|string',
+        ]);
+
+        $record->update($validated);
+
+        return redirect()->route('training-history.index')->with('success', '更新しました');
     }
 }

--- a/resources/views/user/training-history/edit.blade.php
+++ b/resources/views/user/training-history/edit.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <h1 class="mb-4">トレーニング記録の編集</h1>
+
+        <form method="POST" action="{{ route('training-history.update', $record->id) }}">
+            @csrf
+            @method('PUT')
+
+            <div class="mb-3">
+                <label for="training_date" class="form-label">トレーニング日付</label>
+                <input type="datetime-local" name="training_date" id="training_date"
+                    class="form-control @error('training_date') is-invalid @enderror"
+                    value="{{ old('training_date', $record->training_date->format('Y-m-d\TH:i')) }}" required>
+                @error('training_date')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="note" class="form-label">メモ</label>
+                <textarea name="note" id="note" rows="4" class="form-control @error('note') is-invalid @enderror">{{ old('note', $record->note) }}</textarea>
+                @error('note')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="d-flex justify-content-between">
+                <div>
+                    <button type="submit" class="btn btn-primary">保存する</button>
+                    <a href="{{ route('training-history.index') }}" class="btn btn-secondary">キャンセル</a>
+                </div>
+                <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteModal">
+                    削除する
+                </button>
+            </div>
+        </form>
+
+        <!-- 削除確認モーダル -->
+        <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="deleteModalLabel">削除の確認</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        このトレーニング記録を削除してもよろしいですか？この操作は取り消せません。
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+                        <form action="{{ route('training-history.destroy', $record->id) }}" method="POST" class="d-inline">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">削除する</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/user/training-history/partials/advanced_filters.blade.php
+++ b/resources/views/user/training-history/partials/advanced_filters.blade.php
@@ -10,40 +10,45 @@
 <div class="card shadow-sm mb-4">
     <div class="card-body">
         <h3 class="h6 mb-3">詳細フィルター</h3>
-        <div class="row g-3">
-            <div class="col-md-3">
-                <label for="dateFrom" class="form-label small">開始日</label>
-                <input type="date" class="form-control form-control-sm" id="dateFrom" value="">
-            </div>
-            <div class="col-md-3">
-                <label for="dateTo" class="form-label small">終了日</label>
-                <input type="date" class="form-control form-control-sm" id="dateTo" value="">
-            </div>
-            <div class="col-md-3">
-                <label for="templateFilter" class="form-label small">テンプレート</label>
-                <select class="form-select form-select-sm" id="templateFilter">
-                    <option value="all" selected>全テンプレート</option>
-                    <option value="upper">上半身集中トレーニング</option>
-                    <option value="lower">下半身パワーアップ</option>
-                    <option value="hiit">HIIT カーディオ</option>
-                    <option value="core">コア強化プログラム</option>
-                    <option value="stretch">モーニングストレッチ</option>
-                </select>
-            </div>
-            <div class="col-md-3">
-                <label for="search" class="form-label small">キーワード検索</label>
-                <div class="input-group input-group-sm">
-                    <span class="input-group-text">
-                        <i class="fas fa-search"></i>
-                    </span>
-                    <input type="text" class="form-control" id="search" placeholder="メニュー名、メモで検索">
+        <form method="GET" action="{{ route('training-history.index') }}">
+            <div class="row g-3">
+                <div class="col-md-3">
+                    <label for="dateFrom" class="form-label small">開始日</label>
+                    <input type="date" name="date_from" id="dateFrom" class="form-control form-control-sm"
+                        value="{{ request('date_from') }}">
+                </div>
+                <div class="col-md-3">
+                    <label for="dateTo" class="form-label small">終了日</label>
+                    <input type="date" name="date_to" id="dateTo" class="form-control form-control-sm"
+                        value="{{ request('date_to') }}">
+                </div>
+                <div class="col-md-3">
+                    <label for="templateFilter" class="form-label small">テンプレート</label>
+                    <select name="template" id="templateFilter" class="form-select form-select-sm">
+                        <option value="">全テンプレート</option>
+                        <option value="upper" {{ request('template') === 'upper' ? 'selected' : '' }}>上半身集中トレーニング
+                        </option>
+                        <option value="lower" {{ request('template') === 'lower' ? 'selected' : '' }}>下半身パワーアップ
+                        </option>
+                        <option value="hiit" {{ request('template') === 'hiit' ? 'selected' : '' }}>HIIT カーディオ
+                        </option>
+                        <option value="core" {{ request('template') === 'core' ? 'selected' : '' }}>コア強化プログラム</option>
+                        <option value="stretch" {{ request('template') === 'stretch' ? 'selected' : '' }}>モーニングストレッチ
+                        </option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label for="search" class="form-label small">キーワード検索</label>
+                    <div class="input-group input-group-sm">
+                        <span class="input-group-text"><i class="fas fa-search"></i></span>
+                        <input type="text" name="keyword" id="search" class="form-control"
+                            value="{{ request('keyword') }}" placeholder="メニュー名、メモで検索">
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="mt-3 d-flex justify-content-end">
-            <button class="btn btn-primary btn-sm" type="button">
-                検索
-            </button>
-        </div>
+            <div class="mt-3 d-flex justify-content-end">
+                <button class="btn btn-primary btn-sm" type="submit">検索</button>
+            </div>
+        </form>
     </div>
 </div>

--- a/resources/views/user/training-history/partials/header.blade.php
+++ b/resources/views/user/training-history/partials/header.blade.php
@@ -9,22 +9,23 @@
     <div class="container-xxl">
         <div class="d-flex align-items-center justify-content-between py-3">
             <div class="d-flex align-items-center">
-                <button class="btn btn-outline-secondary btn-sm me-3" type="button">
+                <a href="{{ route('dashboard') }}" class="btn btn-outline-secondary btn-sm me-3">
                     <i class="fas fa-arrow-left"></i>
-                </button>
+                </a>
                 <div>
                     <h1 class="h4 mb-0 text-dark">Training History</h1>
                     <p class="text-muted small mb-0">過去のトレーニング記録を確認</p>
                 </div>
             </div>
-            
+
             <div class="d-flex align-items-center gap-2">
-                <button class="btn btn-outline-secondary btn-sm" type="button">
+                <button class="btn btn-outline-secondary btn-sm" type="button" onclick="window.print()">
                     <i class="fas fa-download me-1"></i>
                     エクスポート
                 </button>
-                
-                <button class="btn btn-outline-primary btn-sm" type="button">
+
+                <button class="btn btn-outline-primary btn-sm" type="button"
+                    onclick="document.getElementById('advancedFilters').classList.toggle('d-none')">
                     <i class="fas fa-filter me-1"></i>
                     フィルター
                 </button>

--- a/resources/views/user/training-history/partials/overview.blade.php
+++ b/resources/views/user/training-history/partials/overview.blade.php
@@ -11,7 +11,7 @@
             <h2 class="h5 mb-0">トレーニング概要</h2>
             <i class="fas fa-trending-up text-success"></i>
         </div>
-        
+
         <div class="row g-3">
             <div class="col-6 col-md-3">
                 <div class="bg-white bg-opacity-10 rounded p-3">
@@ -19,45 +19,51 @@
                         <i class="fas fa-bullseye me-2"></i>
                         <span class="small opacity-75">総ワークアウト</span>
                     </div>
-                    <div class="h3 mb-1">8</div>
+                    <div class="h3 mb-1">{{ $records->count() }}</div>
                     <div class="small opacity-75">回</div>
                 </div>
             </div>
-            
+
             <div class="col-6 col-md-3">
                 <div class="bg-white bg-opacity-10 rounded p-3">
                     <div class="d-flex align-items-center mb-2">
                         <i class="fas fa-chart-bar me-2"></i>
                         <span class="small opacity-75">総ボリューム</span>
                     </div>
-                    <div class="h3 mb-1">11,800</div>
+                    <div class="h3 mb-1">
+                        {{ number_format($records->sum(fn($r) => $r->details->sum('volume'))) }}
+                    </div>
                     <div class="small opacity-75">kg</div>
                 </div>
             </div>
-            
+
             <div class="col-6 col-md-3">
                 <div class="bg-white bg-opacity-10 rounded p-3">
                     <div class="d-flex align-items-center mb-2">
                         <i class="fas fa-clock me-2"></i>
                         <span class="small opacity-75">平均時間</span>
                     </div>
-                    <div class="h3 mb-1">45</div>
+                    <div class="h3 mb-1">
+                        {{ $records->count() > 0 ? round($records->sum('duration_minutes') / $records->count()) : 0 }}
+                    </div>
                     <div class="small opacity-75">分</div>
                 </div>
             </div>
-            
+
             <div class="col-6 col-md-3">
                 <div class="bg-white bg-opacity-10 rounded p-3">
                     <div class="d-flex align-items-center mb-2">
                         <i class="fas fa-fire me-2"></i>
                         <span class="small opacity-75">今週の頻度</span>
                     </div>
-                    <div class="h3 mb-1">3</div>
+                    <div class="h3 mb-1">
+                        {{ $records->whereBetween('training_date', [now()->startOfWeek(), now()->endOfWeek()])->count() }}
+                    </div>
                     <div class="small opacity-75">回/週</div>
                 </div>
             </div>
         </div>
-        
+
         <div class="mt-3 p-3 bg-white bg-opacity-10 rounded">
             <div class="d-flex align-items-center">
                 <i class="fas fa-trending-up text-success me-2"></i>

--- a/resources/views/user/training-history/partials/pagination.blade.php
+++ b/resources/views/user/training-history/partials/pagination.blade.php
@@ -2,28 +2,9 @@
 /**
  * Training History Pagination
  * ページネーション（ページ切り替え機能）
- * 
- * 【注意】JavaScript無効のため、ページ切り替えは静的に1ページ目を表示
  */
 --}}
 
-<div class="card shadow-sm">
-    <div class="card-body">
-        <div class="d-flex align-items-center justify-content-between">
-            <div class="text-muted small">
-                8件中 1-8件を表示
-            </div>
-            <div class="d-flex align-items-center gap-2">
-                <button class="btn btn-sm btn-outline-secondary" disabled>
-                    前へ
-                </button>
-                <span class="text-muted small">
-                    1 / 1
-                </span>
-                <button class="btn btn-sm btn-outline-secondary" disabled>
-                    次へ
-                </button>
-            </div>
-        </div>
-    </div>
+<div class="mt-4">
+    {{ $records->links('pagination::bootstrap-5') }}
 </div>

--- a/resources/views/user/training-history/partials/quick_filters.blade.php
+++ b/resources/views/user/training-history/partials/quick_filters.blade.php
@@ -8,18 +8,21 @@
 <div class="card shadow-sm mb-4">
     <div class="card-body">
         <div class="d-flex flex-wrap gap-2">
-            <button type="button" class="btn btn-primary btn-sm">
+            <a href="{{ route('training-history.index') }}" class="btn btn-primary btn-sm">
                 全期間
-            </button>
-            <button type="button" class="btn btn-outline-secondary btn-sm">
+            </a>
+            <a href="{{ route('training-history.index', ['filter' => 'this_week']) }}"
+                class="btn btn-outline-secondary btn-sm">
                 今週
-            </button>
-            <button type="button" class="btn btn-outline-secondary btn-sm">
+            </a>
+            <a href="{{ route('training-history.index', ['filter' => 'this_month']) }}"
+                class="btn btn-outline-secondary btn-sm">
                 今月
-            </button>
-            <button type="button" class="btn btn-outline-secondary btn-sm">
+            </a>
+            <a href="{{ route('training-history.index', ['filter' => 'last_30_days']) }}"
+                class="btn btn-outline-secondary btn-sm">
                 過去30日
-            </button>
+            </a>
         </div>
     </div>
 </div>

--- a/resources/views/user/training-history/partials/records_list.blade.php
+++ b/resources/views/user/training-history/partials/records_list.blade.php
@@ -1,645 +1,158 @@
-{{-- 
-/**
- * Training History Records List
- * トレーニング記録一覧（デスクトップ版テーブル + モバイル版カード）
- */
---}}
-
-{{-- Desktop Table View --}}
-<div class="card shadow-sm mb-4 d-none d-md-block">
-    <div class="table-responsive">
-        <table class="table table-hover mb-0">
-            <thead class="table-light">
-                <tr>
-                    <th scope="col" class="text-nowrap">
-                        <div class="d-flex align-items-center">
-                            <span>日付</span>
-                            <i class="fas fa-chevron-down ms-1 text-muted"></i>
-                        </div>
-                    </th>
-                    <th scope="col">メニュー名</th>
-                    <th scope="col">総セット数</th>
-                    <th scope="col">総回数</th>
-                    <th scope="col">総ボリューム(kg)</th>
-                    <th scope="col">時間(分)</th>
-                    <th scope="col">操作</th>
-                </tr>
-            </thead>
-            <tbody>
-                <!-- トレーニング記録1 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/21 (木)</div>
-                            <div class="text-muted small">10:30</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">上半身集中トレーニング</div>
-                            <div class="text-muted small">胸・背中・肩</div>
-                        </div>
-                    </td>
-                    <td>12</td>
-                    <td>144</td>
-                    <td>2,850</td>
-                    <td>65</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                
-                <!-- トレーニング記録2 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/19 (火)</div>
-                            <div class="text-muted small">14:15</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">下半身パワーアップ</div>
-                            <div class="text-muted small">脚・お尻強化</div>
-                        </div>
-                    </td>
-                    <td>9</td>
-                    <td>81</td>
-                    <td>3,200</td>
-                    <td>50</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                
-                <!-- トレーニング記録3 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/17 (日)</div>
-                            <div class="text-muted small">09:00</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">HIIT カーディオ</div>
-                            <div class="text-muted small">高強度インターバル</div>
-                        </div>
-                    </td>
-                    <td>15</td>
-                    <td>225</td>
-                    <td>0</td>
-                    <td>25</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                
-                <!-- トレーニング記録4 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/15 (金)</div>
-                            <div class="text-muted small">16:45</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">コア強化プログラム</div>
-                            <div class="text-muted small">体幹集中</div>
-                        </div>
-                    </td>
-                    <td>9</td>
-                    <td>90</td>
-                    <td>0</td>
-                    <td>30</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                
-                <!-- トレーニング記録5 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/13 (水)</div>
-                            <div class="text-muted small">11:20</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">上半身集中トレーニング</div>
-                            <div class="text-muted small">胸・背中・肩</div>
-                        </div>
-                    </td>
-                    <td>12</td>
-                    <td>132</td>
-                    <td>2,650</td>
-                    <td>60</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                
-                <!-- トレーニング記録6 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/11 (月)</div>
-                            <div class="text-muted small">08:30</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">下半身パワーアップ</div>
-                            <div class="text-muted small">脚・お尻強化</div>
-                        </div>
-                    </td>
-                    <td>10</td>
-                    <td>90</td>
-                    <td>3,100</td>
-                    <td>55</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                
-                <!-- トレーニング記録7 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/09 (土)</div>
-                            <div class="text-muted small">19:00</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">HIIT カーディオ</div>
-                            <div class="text-muted small">高強度インターバル</div>
-                        </div>
-                    </td>
-                    <td>12</td>
-                    <td>180</td>
-                    <td>0</td>
-                    <td>20</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                
-                <!-- トレーニング記録8 -->
-                <tr>
-                    <td>
-                        <div>
-                            <div class="fw-medium">2024/03/07 (木)</div>
-                            <div class="text-muted small">07:15</div>
-                        </div>
-                    </td>
-                    <td>
-                        <div>
-                            <div class="fw-medium">モーニングストレッチ</div>
-                            <div class="text-muted small">朝の目覚めストレッチ</div>
-                        </div>
-                    </td>
-                    <td>6</td>
-                    <td>60</td>
-                    <td>0</td>
-                    <td>15</td>
-                    <td>
-                        <div class="d-flex gap-1">
-                            <button class="btn btn-sm btn-outline-primary" title="編集">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" title="削除">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
 {{-- Mobile Card View --}}
 <div class="d-md-none">
     <div class="row g-3 mb-4">
-        <!-- モバイル記録カード1 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/21 (木) 10:30</div>
-                            <div class="text-muted small">上半身集中トレーニング</div>
+        @forelse ($records as $record)
+            <div class="col-12">
+                <div class="card shadow-sm">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start mb-3">
+                            <div>
+                                <div class="fw-medium">{{ $record->training_date->format('Y/m/d (D) H:i') }}</div>
+                                <div class="text-muted small">{{ $record->menu->name ?? '-' }}</div>
+                            </div>
+                            <div class="dropdown">
+                                <button class="btn btn-sm btn-outline-secondary" type="button"
+                                    data-bs-toggle="dropdown">
+                                    <i class="fas fa-ellipsis-v"></i>
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li>
+                                        <a class="dropdown-item"
+                                            href="{{ route('training-history.edit', $record->id) }}">
+                                            編集
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <form method="POST"
+                                            action="{{ route('training-history.destroy', $record->id) }}">
+                                            @csrf @method('DELETE')
+                                            <button type="submit" class="dropdown-item text-danger"
+                                                onclick="return confirm('削除しますか？')">
+                                                削除
+                                            </button>
+                                        </form>
+                                    </li>
+                                </ul>
+                            </div>
                         </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
+
+                        <h3 class="h6 mb-3">{{ $record->template->title ?? 'メニュー未設定' }}</h3>
+
+                        <div class="row text-center mb-3">
+                            <div class="col-3">
+                                <div class="fw-medium">{{ $record->details->count() }}</div>
+                                <div class="text-muted small">セット</div>
+                            </div>
+                            <div class="col-3">
+                                <div class="fw-medium">{{ $record->details->sum('reps') }}</div>
+                                <div class="text-muted small">回数</div>
+                            </div>
+                            <div class="col-3">
+                                <div class="fw-medium">{{ number_format($record->details->sum('volume')) }}</div>
+                                <div class="text-muted small">kg</div>
+                            </div>
+                            <div class="col-3">
+                                <div class="fw-medium">{{ $record->duration_minutes ?? '-' }}</div>
+                                <div class="text-muted small">分</div>
+                            </div>
                         </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">胸・背中・肩</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">12</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">144</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">2,850</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">65</div>
-                            <div class="text-muted small">分</div>
-                        </div>
-                    </div>
-                    
-                    <div class="border-top pt-3">
-                        <p class="text-muted small mb-0">
-                            調子良好。重量を少し上げることができた。
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- モバイル記録カード2 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/19 (火) 14:15</div>
-                            <div class="text-muted small">下半身パワーアップ</div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">脚・お尻強化</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">9</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">81</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">3,200</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">50</div>
-                            <div class="text-muted small">分</div>
-                        </div>
-                    </div>
-                    
-                    <div class="border-top pt-3">
-                        <p class="text-muted small mb-0">
-                            スクワットで新記録達成！
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- モバイル記録カード3 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/17 (日) 09:00</div>
-                            <div class="text-muted small">HIIT カーディオ</div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">高強度インターバル</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">15</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">225</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">0</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">25</div>
-                            <div class="text-muted small">分</div>
-                        </div>
-                    </div>
-                    
-                    <div class="border-top pt-3">
-                        <p class="text-muted small mb-0">
-                            短時間で効率的にトレーニング完了
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- モバイル記録カード4 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/15 (金) 16:45</div>
-                            <div class="text-muted small">コア強化プログラム</div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">体幹集中</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">9</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">90</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">0</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">30</div>
-                            <div class="text-muted small">分</div>
+
+                        <div class="border-top pt-3">
+                            <p class="text-muted small mb-0">{{ $record->note ?? '記録なし' }}</p>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
-        
-        <!-- モバイル記録カード5 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/13 (水) 11:20</div>
-                            <div class="text-muted small">上半身集中トレーニング</div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">胸・背中・肩</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">12</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">132</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">2,650</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">60</div>
-                            <div class="text-muted small">分</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- モバイル記録カード6 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/11 (月) 08:30</div>
-                            <div class="text-muted small">下半身パワーアップ</div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">脚・お尻強化</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">10</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">90</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">3,100</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">55</div>
-                            <div class="text-muted small">分</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- モバイル記録カード7 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/09 (土) 19:00</div>
-                            <div class="text-muted small">HIIT カーディオ</div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">高強度インターバル</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">12</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">180</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">0</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">20</div>
-                            <div class="text-muted small">分</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- モバイル記録カード8 -->
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                        <div>
-                            <div class="fw-medium">2024/03/07 (木) 07:15</div>
-                            <div class="text-muted small">モーニングストレッチ</div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                                <i class="fas fa-ellipsis-v"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">編集</a></li>
-                                <li><a class="dropdown-item text-danger" href="#">削除</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    
-                    <h3 class="h6 mb-3">朝の目覚めストレッチ</h3>
-                    
-                    <div class="row text-center mb-3">
-                        <div class="col-3">
-                            <div class="fw-medium">6</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">60</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">0</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                        <div class="col-3">
-                            <div class="fw-medium">15</div>
-                            <div class="text-muted small">分</div>
-                        </div>
-                    </div>
-                </div>
+        @empty
+            <div class="col-12 text-center text-muted">記録がありません。</div>
+        @endforelse
+    </div>
+</div>
+
+{{-- Desktop Table View --}}
+<div class="d-none d-md-block">
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th>日時</th>
+                            <th>メニュー</th>
+                            <th>テンプレート</th>
+                            <th class="text-center">セット数</th>
+                            <th class="text-center">総回数</th>
+                            <th class="text-center">総重量</th>
+                            <th class="text-center">操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($records as $record)
+                            <tr>
+                                <td>
+                                    <a href="{{ route('training-history.show', $record->id) }}"
+                                        class="text-decoration-none">
+                                        {{ $record->training_date->format('Y/m/d (D)') }}<br>
+                                        <small class="text-muted">{{ $record->training_date->format('H:i') }}</small>
+                                    </a>
+                                </td>
+                                <td>{{ $record->menu->name ?? '-' }}</td>
+                                <td>{{ $record->template->title ?? '-' }}</td>
+                                <td class="text-center">{{ $record->details->count() }}</td>
+                                <td class="text-center">{{ $record->details->sum('reps') }}</td>
+                                <td class="text-center">{{ number_format($record->details->sum('volume')) }} kg</td>
+                                <td class="text-center">
+                                    <div class="d-flex justify-content-center gap-2">
+                                        <a href="{{ route('training-history.show', $record->id) }}"
+                                            class="btn btn-sm btn-outline-primary">
+                                            <i class="fas fa-eye"></i>
+                                        </a>
+                                        <a href="{{ route('training-history.edit', $record->id) }}"
+                                            class="btn btn-sm btn-outline-secondary">
+                                            <i class="fas fa-edit"></i>
+                                        </a>
+                                        <button type="button" class="btn btn-sm btn-outline-danger"
+                                            data-bs-toggle="modal" data-bs-target="#deleteModal{{ $record->id }}">
+                                            <i class="fas fa-trash"></i>
+                                        </button>
+
+                                        <!-- Delete Modal -->
+                                        <div class="modal fade" id="deleteModal{{ $record->id }}" tabindex="-1"
+                                            aria-hidden="true">
+                                            <div class="modal-dialog">
+                                                <div class="modal-content">
+                                                    <div class="modal-header">
+                                                        <h5 class="modal-title">削除の確認</h5>
+                                                        <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                                            aria-label="Close"></button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        このトレーニング記録を削除してもよろしいですか？この操作は取り消せません。
+                                                    </div>
+                                                    <div class="modal-footer">
+                                                        <button type="button" class="btn btn-secondary"
+                                                            data-bs-dismiss="modal">キャンセル</button>
+                                                        <form
+                                                            action="{{ route('training-history.destroy', $record->id) }}"
+                                                            method="POST">
+                                                            @csrf
+                                                            @method('DELETE')
+                                                            <button type="submit" class="btn btn-danger">削除する</button>
+                                                        </form>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center py-4 text-muted">記録がありません。</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/resources/views/user/training-history/partials/results_summary.blade.php
+++ b/resources/views/user/training-history/partials/results_summary.blade.php
@@ -1,15 +1,31 @@
 {{-- 
 /**
  * Training History Results Summary
- * 検索結果の概要表示
+ * 検索結果・統計の要約パネル
  */
 --}}
 
-<div class="d-flex align-items-center justify-content-between mb-3">
-    <div class="text-muted small">
-        8件の記録が見つかりました
-    </div>
-    <div class="text-muted small">
-        1-8件を表示
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <h3 class="h6 mb-3">結果サマリー</h3>
+
+        <ul class="list-group list-group-flush small">
+            <li class="list-group-item d-flex justify-content-between">
+                <span>表示件数</span>
+                <span>{{ $records->total() }} 件中 {{ $records->firstItem() }} - {{ $records->lastItem() }} 件表示</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+                <span>合計セット数</span>
+                <span>{{ $totalSets }}</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+                <span>合計回数</span>
+                <span>{{ $totalReps }}</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+                <span>合計ボリューム</span>
+                <span>{{ number_format($totalVolume) }} kg</span>
+            </li>
+        </ul>
     </div>
 </div>

--- a/resources/views/user/training-history/partials/show/exercises.blade.php
+++ b/resources/views/user/training-history/partials/show/exercises.blade.php
@@ -8,127 +8,64 @@
 <div class="card shadow-sm">
     <div class="card-body">
         <h3 class="h5 fw-semibold mb-4">エクササイズ詳細</h3>
-        
+
         <div class="row g-4">
-            {{-- エクササイズ1: ベンチプレス --}}
-            <div class="col-12">
-                <div class="border-bottom pb-4">
-                    <div class="d-flex align-items-center justify-content-between mb-3">
-                        <div class="d-flex align-items-center gap-3">
-                            <div class="badge bg-primary text-white fw-medium px-3 py-2 rounded-pill">
-                                1
-                            </div>
-                            <h4 class="h6 mb-0">ベンチプレス</h4>
-                            {{-- パーソナルレコードバッジ --}}
-                            <div class="badge bg-warning-subtle text-warning d-flex align-items-center gap-1">
-                                <i class="fas fa-award" style="font-size: 0.7rem;"></i>
-                                <span>PR</span>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="row g-3">
-                        <div class="col-6 col-md-3">
-                            <div class="bg-light rounded p-3 text-center">
-                                <div class="h4 fw-bold mb-1">4</div>
-                                <div class="text-muted small">セット</div>
+            @forelse($record->details as $index => $detail)
+                <div class="col-12">
+                    <div class="{{ !$loop->last ? 'border-bottom pb-4' : '' }}">
+                        <div class="d-flex align-items-center justify-content-between mb-3">
+                            <div class="d-flex align-items-center gap-3">
+                                <div class="badge bg-primary text-white fw-medium px-3 py-2 rounded-pill">
+                                    {{ $index + 1 }}
+                                </div>
+                                <h4 class="h6 mb-0">{{ $detail->exercise->name ?? '未設定' }}</h4>
+                                {{-- パーソナルレコードバッジがあれば表示 --}}
+                                @if ($detail->is_personal_record)
+                                    <div class="badge bg-warning-subtle text-warning d-flex align-items-center gap-1">
+                                        <i class="fas fa-award" style="font-size: 0.7rem;"></i>
+                                        <span>PR</span>
+                                    </div>
+                                @endif
                             </div>
                         </div>
-                        <div class="col-6 col-md-3">
-                            <div class="bg-light rounded p-3 text-center">
-                                <div class="h4 fw-bold mb-1">8</div>
-                                <div class="text-muted small">回数</div>
-                            </div>
-                        </div>
-                        <div class="col-6 col-md-3">
-                            <div class="bg-light rounded p-3 text-center">
-                                <div class="h4 fw-bold mb-1">80</div>
-                                <div class="text-muted small">kg</div>
-                            </div>
-                        </div>
-                        <div class="col-6 col-md-3">
-                            <div class="bg-light rounded p-3 text-center">
-                                <div class="h4 fw-bold mb-1">120</div>
-                                <div class="text-muted small">秒</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
 
-            {{-- エクササイズ2: プルアップ --}}
-            <div class="col-12">
-                <div class="border-bottom pb-4">
-                    <div class="d-flex align-items-center justify-content-between mb-3">
-                        <div class="d-flex align-items-center gap-3">
-                            <div class="badge bg-primary text-white fw-medium px-3 py-2 rounded-pill">
-                                2
+                        <div class="row g-3">
+                            <div class="col-6 col-md-3">
+                                <div class="bg-light rounded p-3 text-center">
+                                    <div class="h4 fw-bold mb-1">{{ $detail->sets ?? 1 }}</div>
+                                    <div class="text-muted small">セット</div>
+                                </div>
                             </div>
-                            <h4 class="h6 mb-0">プルアップ</h4>
-                        </div>
-                    </div>
-                    
-                    <div class="row g-3">
-                        <div class="col-6 col-md-3">
-                            <div class="bg-light rounded p-3 text-center">
-                                <div class="h4 fw-bold mb-1">4</div>
-                                <div class="text-muted small">セット</div>
+                            <div class="col-6 col-md-3">
+                                <div class="bg-light rounded p-3 text-center">
+                                    <div class="h4 fw-bold mb-1">{{ $detail->reps }}</div>
+                                    <div class="text-muted small">回数</div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-6 col-md-3">
-                            <div class="bg-light rounded p-3 text-center">
-                                <div class="h4 fw-bold mb-1">10</div>
-                                <div class="text-muted small">回数</div>
-                            </div>
-                        </div>
-                        <div class="col-6 col-md-3">
-                            <div class="bg-light rounded p-3 text-center">
-                                <div class="h4 fw-bold mb-1">90</div>
-                                <div class="text-muted small">秒</div>
-                            </div>
+                            @if ($detail->weight)
+                                <div class="col-6 col-md-3">
+                                    <div class="bg-light rounded p-3 text-center">
+                                        <div class="h4 fw-bold mb-1">{{ $detail->weight }}</div>
+                                        <div class="text-muted small">kg</div>
+                                    </div>
+                                </div>
+                            @endif
+                            @if ($detail->duration_seconds)
+                                <div class="col-6 col-md-3">
+                                    <div class="bg-light rounded p-3 text-center">
+                                        <div class="h4 fw-bold mb-1">{{ $detail->duration_seconds }}</div>
+                                        <div class="text-muted small">秒</div>
+                                    </div>
+                                </div>
+                            @endif
                         </div>
                     </div>
                 </div>
-            </div>
-
-            {{-- エクササイズ3: ショルダープレス --}}
-            <div class="col-12">
-                <div class="d-flex align-items-center justify-content-between mb-3">
-                    <div class="d-flex align-items-center gap-3">
-                        <div class="badge bg-primary text-white fw-medium px-3 py-2 rounded-pill">
-                            3
-                        </div>
-                        <h4 class="h6 mb-0">ショルダープレス</h4>
-                    </div>
+            @empty
+                <div class="col-12 text-center text-muted py-4">
+                    エクササイズ記録はありません
                 </div>
-                
-                <div class="row g-3">
-                    <div class="col-6 col-md-3">
-                        <div class="bg-light rounded p-3 text-center">
-                            <div class="h4 fw-bold mb-1">4</div>
-                            <div class="text-muted small">セット</div>
-                        </div>
-                    </div>
-                    <div class="col-6 col-md-3">
-                        <div class="bg-light rounded p-3 text-center">
-                            <div class="h4 fw-bold mb-1">12</div>
-                            <div class="text-muted small">回数</div>
-                        </div>
-                    </div>
-                    <div class="col-6 col-md-3">
-                        <div class="bg-light rounded p-3 text-center">
-                            <div class="h4 fw-bold mb-1">25</div>
-                            <div class="text-muted small">kg</div>
-                        </div>
-                    </div>
-                    <div class="col-6 col-md-3">
-                        <div class="bg-light rounded p-3 text-center">
-                            <div class="h4 fw-bold mb-1">60</div>
-                            <div class="text-muted small">秒</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            @endforelse
         </div>
     </div>
 </div>

--- a/resources/views/user/training-history/partials/show/header.blade.php
+++ b/resources/views/user/training-history/partials/show/header.blade.php
@@ -1,7 +1,7 @@
 {{-- 
 /**
  * Training History Header
- * ヘッダー部分（タイトル、戻るボタン、エクスポートボタン、フィルターボタン）
+ * ヘッダー部分（タイトル、戻るボタン）
  */
 --}}
 
@@ -9,25 +9,20 @@
     <div class="container-xxl">
         <div class="d-flex align-items-center justify-content-between py-3">
             <div class="d-flex align-items-center">
-                <button class="btn btn-outline-secondary btn-sm me-3" type="button">
+                <a href="{{ route('training-history.index') }}" class="btn btn-outline-secondary btn-sm me-3">
                     <i class="fas fa-arrow-left"></i>
-                </button>
+                </a>
                 <div>
-                    <h1 class="h4 mb-0 text-dark">Training History</h1>
-                    <p class="text-muted small mb-0">過去のトレーニング記録を確認</p>
+                    <h1 class="h4 mb-0 text-dark">トレーニング詳細</h1>
+                    <p class="text-muted small mb-0">トレーニング記録の詳細情報</p>
                 </div>
             </div>
-            
+
             <div class="d-flex align-items-center gap-2">
-                <button class="btn btn-outline-secondary btn-sm" type="button">
-                    <i class="fas fa-download me-1"></i>
-                    エクスポート
-                </button>
-                
-                <button class="btn btn-outline-primary btn-sm" type="button">
-                    <i class="fas fa-filter me-1"></i>
-                    フィルター
-                </button>
+                <a href="{{ route('training-history.edit', $record->id) }}" class="btn btn-outline-primary btn-sm">
+                    <i class="fas fa-edit me-1"></i>
+                    編集
+                </a>
             </div>
         </div>
     </div>

--- a/resources/views/user/training-history/partials/show/hero.blade.php
+++ b/resources/views/user/training-history/partials/show/hero.blade.php
@@ -5,36 +5,42 @@
  */
 --}}
 
-<div class="card shadow-sm mb-4 position-relative overflow-hidden" 
-     style="background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%);">
+<div class="card shadow-sm mb-4 position-relative overflow-hidden"
+    style="background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%);">
     {{-- Background icon --}}
     <div class="position-absolute top-0 end-0 opacity-25">
         <i class="fas fa-bullseye" style="font-size: 8rem; color: white;"></i>
     </div>
-    
+
     <div class="card-body text-white position-relative p-5">
         <div class="d-flex align-items-center mb-2">
             <i class="fas fa-calendar me-2"></i>
-            <span class="text-white-50">2024年03月21日 (木) 10:30</span>
+            <span class="text-white-50">{{ $record->training_date->format('Y年m月d日 (D) H:i') }}</span>
         </div>
-        
-        <h2 class="display-6 fw-bold mb-2">上半身集中トレーニング</h2>
-        
-        <p class="h5 text-white-75 mb-4">胸・背中・肩</p>
-        
+
+        <h2 class="display-6 fw-bold mb-2">{{ $record->menu->name ?? 'トレーニング記録' }}</h2>
+
+        <p class="h5 text-white-75 mb-4">{{ $record->template->title ?? '未設定' }}</p>
+
         <div class="d-flex flex-wrap gap-3 small">
-            <div class="d-flex align-items-center">
-                <i class="fas fa-clock me-1"></i>
-                <span>65分</span>
-            </div>
+            @if ($record->duration_minutes)
+                <div class="d-flex align-items-center">
+                    <i class="fas fa-clock me-1"></i>
+                    <span>{{ $record->duration_minutes }}分</span>
+                </div>
+            @endif
+
             <div class="d-flex align-items-center">
                 <i class="fas fa-bullseye me-1"></i>
-                <span>3種目</span>
+                <span>{{ $record->details->count('exercise_id') }}種目</span>
             </div>
-            <div class="d-flex align-items-center">
-                <i class="fas fa-fire me-1"></i>
-                <span>420kcal</span>
-            </div>
+
+            @if ($record->calories)
+                <div class="d-flex align-items-center">
+                    <i class="fas fa-fire me-1"></i>
+                    <span>{{ $record->calories }}kcal</span>
+                </div>
+            @endif
         </div>
     </div>
 </div>

--- a/resources/views/user/training-history/partials/show/metrics.blade.php
+++ b/resources/views/user/training-history/partials/show/metrics.blade.php
@@ -1,7 +1,7 @@
 {{-- 
 /**
  * Training Detail Metrics Dashboard
- * メトリクスダッシュボード（統計指標と前回比較）
+ * メトリクスダッシュボード（統計指標）
  */
 --}}
 
@@ -12,13 +12,8 @@
             <div class="card-body">
                 <div class="d-flex align-items-center justify-content-between mb-2">
                     <div class="text-muted small fw-medium">総セット数</div>
-                    {{-- 前回比較（上昇） --}}
-                    <div class="badge bg-success-subtle text-success d-flex align-items-center gap-1">
-                        <i class="fas fa-trending-up" style="font-size: 0.7rem;"></i>
-                        <span>8%</span>
-                    </div>
                 </div>
-                <div class="display-6 fw-bold text-dark">12</div>
+                <div class="display-6 fw-bold text-dark">{{ $record->details->count() }}</div>
             </div>
         </div>
     </div>
@@ -29,13 +24,8 @@
             <div class="card-body">
                 <div class="d-flex align-items-center justify-content-between mb-2">
                     <div class="text-muted small fw-medium">総回数</div>
-                    {{-- 前回比較（上昇） --}}
-                    <div class="badge bg-success-subtle text-success d-flex align-items-center gap-1">
-                        <i class="fas fa-trending-up" style="font-size: 0.7rem;"></i>
-                        <span>9%</span>
-                    </div>
                 </div>
-                <div class="display-6 fw-bold text-dark">144</div>
+                <div class="display-6 fw-bold text-dark">{{ $record->details->sum('reps') }}</div>
             </div>
         </div>
     </div>
@@ -46,33 +36,37 @@
             <div class="card-body">
                 <div class="d-flex align-items-center justify-content-between mb-2">
                     <div class="text-muted small fw-medium">総ボリューム</div>
-                    {{-- 前回比較（上昇） --}}
-                    <div class="badge bg-success-subtle text-success d-flex align-items-center gap-1">
-                        <i class="fas fa-trending-up" style="font-size: 0.7rem;"></i>
-                        <span>7%</span>
-                    </div>
                 </div>
-                <div class="display-6 fw-bold text-dark">2,850</div>
+                <div class="display-6 fw-bold text-dark">{{ number_format($record->details->sum('volume')) }}</div>
                 <div class="text-muted small">kg</div>
             </div>
         </div>
     </div>
 
     {{-- 消費カロリー --}}
-    <div class="col-6 col-md-3">
-        <div class="card shadow-sm h-100">
-            <div class="card-body">
-                <div class="d-flex align-items-center justify-content-between mb-2">
-                    <div class="text-muted small fw-medium">消費カロリー</div>
-                    {{-- 前回比較（変化なし） --}}
-                    <div class="badge bg-secondary-subtle text-secondary d-flex align-items-center gap-1">
-                        <i class="fas fa-minus" style="font-size: 0.7rem;"></i>
-                        <span>0%</span>
+    @if ($record->calories)
+        <div class="col-6 col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex align-items-center justify-content-between mb-2">
+                        <div class="text-muted small fw-medium">消費カロリー</div>
                     </div>
+                    <div class="display-6 fw-bold text-dark">{{ $record->calories }}</div>
+                    <div class="text-muted small">kcal</div>
                 </div>
-                <div class="display-6 fw-bold text-dark">420</div>
-                <div class="text-muted small">kcal</div>
             </div>
         </div>
-    </div>
+    @else
+        <div class="col-6 col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex align-items-center justify-content-between mb-2">
+                        <div class="text-muted small fw-medium">トレーニング時間</div>
+                    </div>
+                    <div class="display-6 fw-bold text-dark">{{ $record->duration_minutes ?? '-' }}</div>
+                    <div class="text-muted small">分</div>
+                </div>
+            </div>
+        </div>
+    @endif
 </div>

--- a/resources/views/user/training-history/partials/show/notes.blade.php
+++ b/resources/views/user/training-history/partials/show/notes.blade.php
@@ -1,9 +1,7 @@
 {{-- 
 /**
  * Training Detail Notes Section
- * メモセクション（編集可能なノート）
- * 
- * 【注意】JavaScript無効のため、編集機能は表示のみ
+ * メモセクション
  */
 --}}
 
@@ -11,36 +9,14 @@
     <div class="card-body">
         <div class="d-flex align-items-center justify-content-between mb-3">
             <h3 class="h5 fw-semibold mb-0">メモ</h3>
-            <button class="btn btn-outline-primary btn-sm" type="button">
+            <a href="{{ route('training-history.edit', $record->id) }}" class="btn btn-outline-primary btn-sm">
                 <i class="fas fa-edit"></i>
-            </button>
+            </a>
         </div>
-        
-        {{-- 通常表示モード --}}
+
         <div id="notes-display">
             <div class="text-muted">
-                調子良好。重量を少し上げることができた。次回はベンチプレスで85kgに挑戦したい。
-                <!-- 動的化時は{{ $record->notes ?? 'メモはありません' }}に置換 -->
-            </div>
-        </div>
-        
-        {{-- 編集モード（JavaScript無効のため非表示） --}}
-        <div id="notes-edit" class="d-none">
-            <div class="mb-3">
-                <textarea 
-                    class="form-control" 
-                    rows="4" 
-                    placeholder="トレーニングのメモを入力...">調子良好。重量を少し上げることができた。次回はベンチプレスで85kgに挑戦したい。</textarea>
-            </div>
-            <div class="d-flex gap-2">
-                <button class="btn btn-primary btn-sm" type="button">
-                    <i class="fas fa-check me-1"></i>
-                    保存
-                </button>
-                <button class="btn btn-outline-secondary btn-sm" type="button">
-                    <i class="fas fa-times me-1"></i>
-                    キャンセル
-                </button>
+                {{ $record->note ?? 'メモはありません' }}
             </div>
         </div>
     </div>

--- a/resources/views/user/training-history/partials/show/personal_records.blade.php
+++ b/resources/views/user/training-history/partials/show/personal_records.blade.php
@@ -5,21 +5,34 @@
  */
 --}}
 
-<div class="card border-warning shadow-sm" style="background: linear-gradient(135deg, #fef3c7 0%, #fed7aa 100%);">
-    <div class="card-body">
-        <div class="d-flex align-items-center gap-2 mb-3">
-            <i class="fas fa-award text-warning"></i>
-            <h3 class="h5 fw-semibold text-warning-emphasis mb-0">パーソナルレコード</h3>
-        </div>
-        
-        <div class="d-flex flex-column gap-2">
-            <div class="d-flex align-items-center justify-content-between">
-                <span class="text-warning-emphasis">ベンチプレス</span>
-                <div class="d-flex align-items-center gap-2">
-                    <span class="fw-medium text-warning-emphasis">80kg</span>
-                    <span class="fw-medium text-warning-emphasis">8回</span>
-                </div>
+@php
+    // 個人記録を達成したエクササイズを取得
+    $personalRecords = $record->details->filter(function ($detail) {
+        return $detail->is_personal_record ?? false;
+    });
+@endphp
+
+@if ($personalRecords->count() > 0)
+    <div class="card border-warning shadow-sm" style="background: linear-gradient(135deg, #fef3c7 0%, #fed7aa 100%);">
+        <div class="card-body">
+            <div class="d-flex align-items-center gap-2 mb-3">
+                <i class="fas fa-award text-warning"></i>
+                <h3 class="h5 fw-semibold text-warning-emphasis mb-0">パーソナルレコード</h3>
+            </div>
+
+            <div class="d-flex flex-column gap-2">
+                @foreach ($personalRecords as $record)
+                    <div class="d-flex align-items-center justify-content-between">
+                        <span class="text-warning-emphasis">{{ $record->exercise->name ?? '未設定' }}</span>
+                        <div class="d-flex align-items-center gap-2">
+                            @if ($record->weight)
+                                <span class="fw-medium text-warning-emphasis">{{ $record->weight }}kg</span>
+                            @endif
+                            <span class="fw-medium text-warning-emphasis">{{ $record->reps }}回</span>
+                        </div>
+                    </div>
+                @endforeach
             </div>
         </div>
     </div>
-</div>
+@endif

--- a/resources/views/user/training-history/partials/show/quick_stats.blade.php
+++ b/resources/views/user/training-history/partials/show/quick_stats.blade.php
@@ -8,27 +8,37 @@
 <div class="card shadow-sm mb-4">
     <div class="card-body">
         <h3 class="h5 fw-semibold mb-4">クイック統計</h3>
-        
+
         <div class="d-flex flex-column gap-3">
-            <div class="d-flex align-items-center justify-content-between">
-                <span class="text-muted">平均セット時間</span>
-                <span class="fw-medium">5分</span>
-            </div>
-            
-            <div class="d-flex align-items-center justify-content-between">
-                <span class="text-muted">セット当たり回数</span>
-                <span class="fw-medium">12回</span>
-            </div>
-            
-            <div class="d-flex align-items-center justify-content-between">
-                <span class="text-muted">平均重量</span>
-                <span class="fw-medium">20kg</span>
-            </div>
-            
-            <div class="d-flex align-items-center justify-content-between">
-                <span class="text-muted">カロリー効率</span>
-                <span class="fw-medium">6kcal/分</span>
-            </div>
+            @if ($record->duration_minutes && $record->details->count() > 0)
+                <div class="d-flex align-items-center justify-content-between">
+                    <span class="text-muted">平均セット時間</span>
+                    <span class="fw-medium">{{ round($record->duration_minutes / $record->details->count(), 1) }}分</span>
+                </div>
+            @endif
+
+            @if ($record->details->count() > 0)
+                <div class="d-flex align-items-center justify-content-between">
+                    <span class="text-muted">セット当たり回数</span>
+                    <span
+                        class="fw-medium">{{ round($record->details->sum('reps') / $record->details->count(), 1) }}回</span>
+                </div>
+            @endif
+
+            @if ($record->details->sum('weight') > 0 && $record->details->whereNotNull('weight')->count() > 0)
+                <div class="d-flex align-items-center justify-content-between">
+                    <span class="text-muted">平均重量</span>
+                    <span
+                        class="fw-medium">{{ round($record->details->sum('weight') / $record->details->whereNotNull('weight')->count(), 1) }}kg</span>
+                </div>
+            @endif
+
+            @if ($record->calories && $record->duration_minutes)
+                <div class="d-flex align-items-center justify-content-between">
+                    <span class="text-muted">カロリー効率</span>
+                    <span class="fw-medium">{{ round($record->calories / $record->duration_minutes, 1) }}kcal/分</span>
+                </div>
+            @endif
         </div>
     </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,7 +92,7 @@ Route::middleware(['auth', 'setup'])->group(function () {
 
     // training history
     Route::resource('training-history', TrainingHistoryController::class)->except(['show']);
-    Route::get('/training-history/show', [TrainingHistoryController::class, 'show']);
+    Route::get('/training-history/show/{id}', [TrainingHistoryController::class, 'show'])->name('training-history.show');
 
     // home route (for compatibility)
     Route::get('/home', function () {


### PR DESCRIPTION
- Add quick filter options (this week, this month, last 30 days)
- Implement responsive UI with card view for mobile and table view for desktop
- Connect view templates with real data from database
- Add delete confirmation modal
- Implement pagination for history records
- Fix navigation links and back buttons
- Update detail view to display exercise statistics and metrics
- Improve UX with clear visual hierarchy and interactive elements

This PR completes the basic CRUD operations for training history records and prepares the foundation for the upcoming Statistics & CSV Export feature.