### PR TITLE
Implement old file removal on image upload & add cleanup command

### DIFF
--- a/app/Console/Commands/CleanUnusedStorageFiles.php
+++ b/app/Console/Commands/CleanUnusedStorageFiles.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Exercise;
+use App\Models\Profile;
+use App\Models\Template;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class CleanUnusedStorageFiles extends Command
+{
+    /**
+     * コンソールコマンドの名前と形式
+     *
+     * @var string
+     */
+    protected $signature = 'storage:clean-unused {--dry-run : 削除されるファイルを表示するだけで実際には削除しない}';
+
+    /**
+     * コンソールコマンドの説明
+     *
+     * @var string
+     */
+    protected $description = 'データベースで参照されていない未使用の画像ファイルをストレージから削除';
+
+    /**
+     * コマンドの実行
+     */
+    public function handle()
+    {
+        $this->info('ストレージのクリーンアップを開始します...');
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('ドライランモードで実行中。ファイルは実際には削除されません。');
+        }
+
+        // ストレージディレクトリ内のすべてのファイルを取得
+        $this->cleanDirectory('avatars', $this->getProfileAvatars(), $dryRun);
+        $this->cleanDirectory('exercises', $this->getExerciseImages(), $dryRun);
+        $this->cleanDirectory('images/templates', $this->getTemplateImages(), $dryRun);
+        $this->cleanThumbnails($dryRun);
+
+        $this->info('ストレージのクリーンアップが完了しました！');
+    }
+
+    /**
+     * 特定のディレクトリから参照リストに含まれていないファイルを削除
+     */
+    private function cleanDirectory(string $directory, array $referencedFiles, bool $dryRun): void
+    {
+        $this->info("ディレクトリのクリーンアップ: {$directory}");
+
+        // ディレクトリ内のすべてのファイルを取得
+        $existingFiles = Storage::disk('public')->files($directory);
+        $filesToDelete = [];
+
+        // クリーンアップ前のカウント
+        $beforeCount = count($existingFiles);
+        $this->info("クリーンアップ前のファイル数: {$beforeCount}");
+
+        // 一貫した比較のために参照ファイルのパスを正規化
+        $normalizedReferencedFiles = array_map(function ($path) {
+            return $this->normalizePath($path);
+        }, $referencedFiles);
+
+        // データベースで参照されていないファイルを検索
+        foreach ($existingFiles as $file) {
+            // ストレージファイルパスの正規化
+            $normalizedFilePath = $this->normalizePath($file);
+
+            if (! in_array($normalizedFilePath, $normalizedReferencedFiles)) {
+                $filesToDelete[] = $file;
+                $this->line("削除対象: {$file} (正規化後: {$normalizedFilePath})");
+            }
+        }
+
+        // ドライランモードでなければ未使用ファイルを削除
+        if (! $dryRun && count($filesToDelete) > 0) {
+            Storage::disk('public')->delete($filesToDelete);
+            $this->info("ディレクトリ {$directory} から ".count($filesToDelete).' 個の未使用ファイルを削除しました');
+        } else {
+            $this->info("ディレクトリ {$directory} で ".count($filesToDelete).' 個の削除対象ファイルを検出しました');
+        }
+
+        // クリーンアップ後のカウント
+        $afterCount = $beforeCount - count($filesToDelete);
+        $this->info("クリーンアップ後のファイル数: {$afterCount}");
+    }
+
+    /**
+     * 既存のテンプレート画像に基づいてサムネイルディレクトリをクリーンアップ
+     */
+    private function cleanThumbnails(bool $dryRun): void
+    {
+        $this->info('サムネイルディレクトリのクリーンアップ');
+
+        // すべてのテンプレート画像を取得（対応するサムネイルが必要）
+        $templateImages = $this->getTemplateImages();
+
+        // パスなしでベースファイル名を抽出
+        $templateImageFilenames = array_map(function ($path) {
+            return basename($path);
+        }, $templateImages);
+
+        // サムネイルディレクトリ内のすべてのファイルを取得
+        $existingThumbnails = Storage::disk('public')->files('thumbnails');
+        $filesToDelete = [];
+
+        // クリーンアップ前のカウント
+        $beforeCount = count($existingThumbnails);
+        $this->info("クリーンアップ前のサムネイル数: {$beforeCount}");
+
+        // 対応するテンプレート画像がないサムネイルを検索
+        foreach ($existingThumbnails as $thumbnail) {
+            $filename = basename($thumbnail);
+
+            if (! in_array($filename, $templateImageFilenames)) {
+                $filesToDelete[] = $thumbnail;
+                $this->line("削除対象: {$thumbnail}");
+            }
+        }
+
+        // ドライランモードでなければ未使用サムネイルを削除
+        if (! $dryRun && count($filesToDelete) > 0) {
+            Storage::disk('public')->delete($filesToDelete);
+            $this->info('未使用サムネイル '.count($filesToDelete).' 個を削除しました');
+        } else {
+            $this->info('削除対象のサムネイル '.count($filesToDelete).' 個を検出しました');
+        }
+
+        // クリーンアップ後のカウント
+        $afterCount = $beforeCount - count($filesToDelete);
+        $this->info("クリーンアップ後のサムネイル数: {$afterCount}");
+    }
+
+    /**
+     * 一貫した比較のためにファイルパスを正規化
+     */
+    private function normalizePath(string $path): string
+    {
+        // 先頭の 'public/storage/', 'storage/', 'public/' を安全に削除
+        $path = preg_replace('#^(public/storage/|storage/|public/)#', '', $path);
+
+        // ディレクトリ区切り文字をスラッシュに正規化
+        $path = str_replace('\\', '/', $path);
+
+        return $path;
+    }
+
+    /**
+     * データベースで参照されているすべてのプロフィールアバターを取得
+     */
+    private function getProfileAvatars(): array
+    {
+        return Profile::whereNotNull('avatar')
+            ->pluck('avatar')
+            ->toArray();
+    }
+
+    /**
+     * データベースで参照されているすべてのエクササイズ画像を取得
+     */
+    private function getExerciseImages(): array
+    {
+        return Exercise::whereNotNull('image_path')
+            ->pluck('image_path')
+            ->toArray();
+    }
+
+    /**
+     * データベースで参照されているすべてのテンプレート画像を取得
+     */
+    private function getTemplateImages(): array
+    {
+        return Template::whereNotNull('image_path')
+            ->pluck('image_path')
+            ->toArray();
+    }
+}

--- a/app/Http/Controllers/Admin/AdminExerciseController.php
+++ b/app/Http/Controllers/Admin/AdminExerciseController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ExerciseRequest;
 use App\Models\Exercise;
+use App\Utilities\FileUtility;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
@@ -51,8 +52,11 @@ class AdminExerciseController extends Controller
 
         // Handle image upload
         if ($request->hasFile('image')) {
-            $imagePath = $request->file('image')->store('exercises', 'public');
-            $data['image_path'] = $imagePath;
+            $data['image_path'] = FileUtility::replaceFile(
+                $request->file('image'),
+                null,
+                'exercises'
+            );
         }
 
         Exercise::create($data);
@@ -85,13 +89,11 @@ class AdminExerciseController extends Controller
 
         // Handle image upload
         if ($request->hasFile('image')) {
-            // Delete old image if exists
-            if ($exercise->image_path && Storage::disk('public')->exists($exercise->image_path)) {
-                Storage::disk('public')->delete($exercise->image_path);
-            }
-
-            $imagePath = $request->file('image')->store('exercises', 'public');
-            $data['image_path'] = $imagePath;
+            $data['image_path'] = FileUtility::replaceFile(
+                $request->file('image'),
+                $exercise->image_path,
+                'exercises'
+            );
         }
         $exercise->update($data);
 

--- a/app/Http/Controllers/Admin/AdminTemplateController.php
+++ b/app/Http/Controllers/Admin/AdminTemplateController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\TemplateRequest;
 use App\Models\Exercise;
 use App\Models\Template;
+use App\Utilities\FileUtility;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -81,7 +82,11 @@ class AdminTemplateController extends Controller
 
             // Handle thumbnail upload
             if ($request->hasFile('thumbnail') && $request->file('thumbnail')->isValid()) {
-                $data['image_path'] = $request->file('thumbnail')->store('images/templates', 'public');
+                $data['image_path'] = FileUtility::replaceFile(
+                    $request->file('thumbnail'),
+                    null,
+                    'images/templates'
+                );
             }
 
             $template = Template::create($data);
@@ -185,7 +190,11 @@ class AdminTemplateController extends Controller
 
             // Handle thumbnail upload
             if ($request->hasFile('thumbnail') && $request->file('thumbnail')->isValid()) {
-                $data['image_path'] = $request->file('thumbnail')->store('images/templates', 'public');
+                $data['image_path'] = FileUtility::replaceFile(
+                    $request->file('thumbnail'),
+                    $template->image_path,
+                    'images/templates'
+                );
             }
 
             $template->update($data);

--- a/app/Http/Controllers/ExerciseController.php
+++ b/app/Http/Controllers/ExerciseController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ExerciseRequest;
 use App\Models\Exercise;
+use App\Utilities\FileUtility;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
@@ -50,8 +51,11 @@ class ExerciseController extends Controller
 
         // Handle image upload
         if ($request->hasFile('image')) {
-            $imagePath = $request->file('image')->store('exercises', 'public');
-            $data['image_path'] = $imagePath;
+            $data['image_path'] = FileUtility::replaceFile(
+                $request->file('image'),
+                null,
+                'exercises'
+            );
         }
 
         Exercise::create($data);
@@ -84,13 +88,11 @@ class ExerciseController extends Controller
 
         // Handle image upload
         if ($request->hasFile('image')) {
-            // Delete old image if exists
-            if ($exercise->image_path && Storage::disk('public')->exists($exercise->image_path)) {
-                Storage::disk('public')->delete($exercise->image_path);
-            }
-
-            $imagePath = $request->file('image')->store('exercises', 'public');
-            $data['image_path'] = $imagePath;
+            $data['image_path'] = FileUtility::replaceFile(
+                $request->file('image'),
+                $exercise->image_path,
+                'exercises'
+            );
         }
         $exercise->update($data);
 

--- a/app/Http/Controllers/User/AccountController.php
+++ b/app/Http/Controllers/User/AccountController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
+use App\Utilities\FileUtility;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
@@ -37,13 +38,12 @@ class AccountController extends Controller
         $user = Auth::user();
         $profile = $user->profile;
 
-        // Delete previous avatar if exists
-        if ($profile->avatar) {
-            Storage::disk('public')->delete($profile->avatar);
-        }
-
-        // Store the new avatar
-        $avatarPath = $request->file('avatar')->store('avatars', 'public');
+        // Replace avatar using utility
+        $avatarPath = FileUtility::replaceFile(
+            $request->file('avatar'),
+            $profile->avatar,
+            'avatars'
+        );
 
         // Update profile with new avatar path
         $profile->update([

--- a/app/Utilities/FileUtility.php
+++ b/app/Utilities/FileUtility.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Utilities;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class FileUtility
+{
+    /**
+     * Replace an old file with a new one
+     *
+     * @param  UploadedFile  $file  New file to upload
+     * @param  string|null  $oldFilePath  Path to the old file that will be deleted
+     * @param  string  $directory  Directory to store the new file
+     * @return string Path to the new file
+     */
+    public static function replaceFile(UploadedFile $file, ?string $oldFilePath, string $directory): string
+    {
+        // Delete old file if it exists
+        if ($oldFilePath && Storage::disk('public')->exists($oldFilePath)) {
+            Storage::disk('public')->delete($oldFilePath);
+        }
+
+        // Store and return path to the new file
+        return $file->store($directory, 'public');
+    }
+}


### PR DESCRIPTION
- Create FileUtility class for standardized file replacement
- Update all image upload controllers to remove old files
- Add storage:clean-unused command to remove orphaned files
- Optimize storage space by cleaning up unused images