### PR TITLE
Fix modal close issue in template creation page

### DIFF
--- a/resources/views/admin/templates/create.blade.php
+++ b/resources/views/admin/templates/create.blade.php
@@ -254,26 +254,52 @@
             const modalElement = document.getElementById('exerciseModal');
 
             // Bootstrap Modal のためのヘルパー関数
+            let modalBackdrop = null;
+
             function showModal() {
                 if (modalElement) {
+                    // 既存のモーダル状態をクリア
+                    hideModal();
+
+                    // モーダルを表示
                     modalElement.classList.add('show');
                     modalElement.style.display = 'block';
+                    modalElement.setAttribute('aria-modal', 'true');
+                    modalElement.setAttribute('role', 'dialog');
+
+                    // bodyにクラスを追加
                     document.body.classList.add('modal-open');
-                    const backdrop = document.createElement('div');
-                    backdrop.className = 'modal-backdrop fade show';
-                    document.body.appendChild(backdrop);
+                    document.body.style.overflow = 'hidden';
+
+                    // 新しいbackdropを作成
+                    modalBackdrop = document.createElement('div');
+                    modalBackdrop.className = 'modal-backdrop fade show';
+                    document.body.appendChild(modalBackdrop);
                 }
             }
 
             function hideModal() {
                 if (modalElement) {
+                    // モーダルを非表示
                     modalElement.classList.remove('show');
                     modalElement.style.display = 'none';
+                    modalElement.removeAttribute('aria-modal');
+                    modalElement.setAttribute('aria-hidden', 'true');
+
+                    // bodyのスタイルを元に戻す
                     document.body.classList.remove('modal-open');
-                    const backdrop = document.querySelector('.modal-backdrop');
-                    if (backdrop) {
-                        backdrop.parentNode.removeChild(backdrop);
+                    document.body.style.overflow = '';
+                    document.body.style.paddingRight = '';
+
+                    // backdropを削除
+                    if (modalBackdrop && modalBackdrop.parentNode) {
+                        modalBackdrop.parentNode.removeChild(modalBackdrop);
                     }
+
+                    // 他のすべてのbackdropも削除（念のため）
+                    document.querySelectorAll('.modal-backdrop').forEach(el => {
+                        el.parentNode.removeChild(el);
+                    });
                 }
             }
 
@@ -296,6 +322,7 @@
             if (addExerciseBtn) {
                 addExerciseBtn.addEventListener('click', function(e) {
                     e.preventDefault();
+                    e.stopPropagation(); // イベント伝播を止める
                     showModal();
                 });
             }


### PR DESCRIPTION
## Fix Exercise Modal Close Issue

### Problem
When closing the exercise selection modal on the template creation page, the screen became unresponsive. This happened because the modal backdrop wasn't being properly removed and the body's overflow property wasn't being reset correctly.

### Solution
- Improved the modal handling functions to properly clean up modal elements
- Added proper aria attributes for accessibility 
- Ensured all modal backdrops are removed when closing the modal
- Reset body styles completely to restore page interactivity

### How to Test
1. Go to `/admin/templates/create`
2. Click "Add Exercise" button to open the modal
3. Close the modal using the close button
4. Verify the page remains interactive
5. Re-open and close the modal several times to ensure consistent behavior

This fix improves the user experience by ensuring the template creation page remains fully functional after interacting with the exercise selection modal.